### PR TITLE
Code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,75 +2,127 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
- professional setting
+  professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at codeconnectorteam@gmail.com. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+reported to the community leaders responsible for enforcement at
+codeconnectorteam@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
 
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,16 +52,24 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
       <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="#page-top">Code Connector</a>
+        <a class="navbar-brand" href="/">Code Connector</a>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="d-none d-md-inline">Menu</span><span class="d-inline d-md-none"><i class="fas fa-bars"></i></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
-            <li class="nav-item">
-              <a class="nav-link" href="/learn" data-target="#">Learn</a>
-            </li>
             <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="getInvolvedNavbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Get Involved</a>
+              <div class="dropdown-menu" aria-labelledby="getInvolvedNavbarDropdownMenuLink">
+                <a class="dropdown-item" href="/learn" data-target="#">Learn to Code</a>
+                <a class="dropdown-item" href="/volunteer" data-target="#">Volunteer</a>
+                <a class="dropdown-item" href="/sponsor" data-target="#">Sponsor</a>
+                <a class="dropdown-item" href="/assistance" data-target="#">Partner</a>
+                <div class="dropdown-divider"></div>
+                <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
+              </div>
+            </li>
+            <!-- <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="locationsNavbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
@@ -74,19 +82,12 @@
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
-            </li>
-            <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="supportNavbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Support
-              </a>
-              <div class="dropdown-menu" aria-labelledby="supportNavbarDropdownMenuLink">
-                <a class="dropdown-item" href="/volunteer" data-target="#">Get involved</a>
-                <a class="dropdown-item" href="/sponsor" data-target="#">Through sponsorship</a>
-                <a class="dropdown-item" href="/assistance" data-target="#">Receive meetup assistance</a>
-              </div>
-            </li>
+            </li>-->
             <li class="nav-item">
               <a class="nav-link" href="/about" data-target="#">About</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/code-of-conduct" data-target="#">Code of Conduct</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -1,0 +1,192 @@
+---
+title: Code of Conduct
+---
+
+<header>
+    <div class="overlay"></div>
+    <video
+        playsinline="playsinline"
+        autoplay="autoplay"
+        muted="muted"
+        loop="loop"
+    >
+        <source src="/content/videos/talk2.mp4" type="video/mp4" />
+    </video>
+    <div class="container h-100">
+        <div class="d-flex h-100 text-center align-items-center">
+            <div class="w-100 text-white">
+                <h1>Code of Conduct</h1>
+            </div>
+        </div>
+    </div>
+</header>
+
+<section id="code-of-conduct" class="container">
+    <h2 id="our-pledge">Our Pledge</h2>
+    <p>
+        We as members, contributors, and leaders pledge to make participation in
+        our community a harassment-free experience for everyone, regardless of
+        age, body size, visible or invisible disability, ethnicity, sex
+        characteristics, gender identity and expression, level of experience,
+        education, socio-economic status, nationality, personal appearance,
+        race, religion, or sexual identity and orientation.
+    </p>
+    <p>
+        We pledge to act and interact in ways that contribute to an open,
+        welcoming, diverse, inclusive, and healthy community.
+    </p>
+    <h2 id="our-standards">Our Standards</h2>
+    <p>
+        Examples of behavior that contributes to a positive environment for our
+        community include:
+    </p>
+    <ul>
+        <li>Demonstrating empathy and kindness toward other people</li>
+        <li>
+            Being respectful of differing opinions, viewpoints, and experiences
+        </li>
+        <li>Giving and gracefully accepting constructive feedback</li>
+        <li>
+            Accepting responsibility and apologizing to those affected by our
+            mistakes, and learning from the experience
+        </li>
+        <li>
+            Focusing on what is best not just for us as individuals, but for the
+            overall community
+        </li>
+    </ul>
+    <p>Examples of unacceptable behavior include:</p>
+    <ul>
+        <li>
+            The use of sexualized language or imagery, and sexual attention or
+            advances of any kind
+        </li>
+        <li>
+            Trolling, insulting or derogatory comments, and personal or
+            political attacks
+        </li>
+        <li>Public or private harassment</li>
+        <li>
+            Publishing others’ private information, such as a physical or email
+            address, without their explicit permission
+        </li>
+        <li>
+            Other conduct which could reasonably be considered inappropriate in
+            a professional setting
+        </li>
+    </ul>
+    <h2 id="enforcement-responsibilities">Enforcement Responsibilities</h2>
+    <p>
+        Community leaders are responsible for clarifying and enforcing our
+        standards of acceptable behavior and will take appropriate and fair
+        corrective action in response to any behavior that they deem
+        inappropriate, threatening, offensive, or harmful.
+    </p>
+    <p>
+        Community leaders have the right and responsibility to remove, edit, or
+        reject comments, commits, code, wiki edits, issues, and other
+        contributions that are not aligned to this Code of Conduct, and will
+        communicate reasons for moderation decisions when appropriate.
+    </p>
+    <h2 id="scope">Scope</h2>
+    <p>
+        This Code of Conduct applies within all community spaces, and also
+        applies when an individual is officially representing the community in
+        public spaces. Examples of representing our community include using an
+        official e-mail address, posting via an official social media account,
+        or acting as an appointed representative at an online or offline event.
+    </p>
+    <h2 id="enforcement">Enforcement</h2>
+    <p>
+        Instances of abusive, harassing, or otherwise unacceptable behavior may
+        be reported to the community leaders responsible for enforcement at
+        <a
+            href="mailto:codeconnectorteam@gmail.com?subject=Code%20of%20Conduct%20Report"
+            >codeconnectorteam@gmail.com</a
+        >. All complaints will be reviewed and investigated promptly and fairly.
+    </p>
+    <p>
+        All community leaders are obligated to respect the privacy and security
+        of the reporter of any incident.
+    </p>
+    <h2 id="enforcement-guidelines">Enforcement Guidelines</h2>
+    <p>
+        Community leaders will follow these Community Impact Guidelines in
+        determining the consequences for any action they deem in violation of
+        this Code of Conduct:
+    </p>
+    <h3 id="1-correction">1. Correction</h3>
+    <p>
+        <strong>Community Impact</strong>: Use of inappropriate language or
+        other behavior deemed unprofessional or unwelcome in the community.
+    </p>
+    <p>
+        <strong>Consequence</strong>: A private, written warning from community
+        leaders, providing clarity around the nature of the violation and an
+        explanation of why the behavior was inappropriate. A public apology may
+        be requested.
+    </p>
+    <h3 id="2-warning">2. Warning</h3>
+    <p>
+        <strong>Community Impact</strong>: A violation through a single incident
+        or series of actions.
+    </p>
+    <p>
+        <strong>Consequence</strong>: A warning with consequences for continued
+        behavior. No interaction with the people involved, including unsolicited
+        interaction with those enforcing the Code of Conduct, for a specified
+        period of time. This includes avoiding interactions in community spaces
+        as well as external channels like social media. Violating these terms
+        may lead to a temporary or permanent ban.
+    </p>
+    <h3 id="3-temporary-ban">3. Temporary Ban</h3>
+    <p>
+        <strong>Community Impact</strong>: A serious violation of community
+        standards, including sustained inappropriate behavior.
+    </p>
+    <p>
+        <strong>Consequence</strong>: A temporary ban from any sort of
+        interaction or public communication with the community for a specified
+        period of time. No public or private interaction with the people
+        involved, including unsolicited interaction with those enforcing the
+        Code of Conduct, is allowed during this period. Violating these terms
+        may lead to a permanent ban.
+    </p>
+    <h3 id="4-permanent-ban">4. Permanent Ban</h3>
+    <p>
+        <strong>Community Impact</strong>: Demonstrating a pattern of violation
+        of community standards, including sustained inappropriate behavior,
+        harassment of an individual, or aggression toward or disparagement of
+        classes of individuals.
+    </p>
+    <p>
+        <strong>Consequence</strong>: A permanent ban from any sort of public
+        interaction within the community.
+    </p>
+    <h2 id="attribution">Attribution</h2>
+    <p>
+        This Code of Conduct is adapted from the
+        <a href="https://www.contributor-covenant.org">Contributor Covenant</a>,
+        version 2.0, available at
+        <a
+            href="https://www.contributor-covenant.org/version/2/0/code_of_conduct.html"
+            >https://www.contributor-covenant.org/version/2/0/code_of_conduct.html</a
+        >.
+    </p>
+    <p>
+        Community Impact Guidelines were inspired by
+        <a href="https://github.com/mozilla/diversity"
+            >Mozilla’s code of conduct enforcement ladder</a
+        >.
+    </p>
+    <p>
+        For answers to common questions about this code of conduct, see the FAQ
+        at
+        <a href="https://www.contributor-covenant.org/faq"
+            >https://www.contributor-covenant.org/faq</a
+        >. Translations are available at
+        <a href="https://www.contributor-covenant.org/translations"
+            >https://www.contributor-covenant.org/translations</a
+        >.
+    </p>
+</section>


### PR DESCRIPTION
- Update Code of Conduct to 2.0
- Host the code of conduct on the website
- Refactor the navigation

This seemed like the best way to fit everything we care about into the
navbar according to the mediaquery breakpoints the site is based on.

<img width="627" alt="Screen Shot 2020-07-23 at 11 22 45 PM" src="https://user-images.githubusercontent.com/5741299/88358355-9a60fa00-cd3c-11ea-98ec-cd8cd0774ea2.png">
