### PR TITLE
Added more descriptive text for /learn and /about.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@ title: Home
             <p class="text-muted mt-4">Videos, bootcamps, recruiting agencies, college degree programs... there are so many options! We want you to get what you need and at a price you can afford.</p>                
           </div>
           <div class="card-footer p-4">
-            <a class="btn btn-primary" href="/learn">Start</a>   
+            <a class="btn btn-primary" href="/learn">Learn</a>   
           </div>
         </div>
       </div>
@@ -520,7 +520,7 @@ title: Home
     <div class="row pt-5 d-flex justify-content-center">
       <div class="col-lg-6 text-center text-light">
         <p>We're especially thankful to be supported by the awesome folks at <a href="https://memphistechnology.org/" target="_blank" rel="noopener" class="text-white">Memphis Technology Foundation</a>.</p>
-        <a href="about.html#partner" class="btn btn-light shadow mt-3">Learn more</a>
+        <a href="about.html#partner" class="btn btn-light shadow mt-3">Learn more about MTF</a>
         <!--
         <a class="btn btn-light shadow mt-3 text-wrap" href="/about">Learn about our partnership</a>
         -->


### PR DESCRIPTION
I changed the `/learn` link text to Learn so that it would be more descriptive rather then "Start." I also changed the link text that leads to the Memphis Technology Foundation FAQs to be "Learn more about MTF" so that users more explicitly know where they are being directed.