### PR TITLE
Footer button mobile fix

### DIFF
--- a/css/core.scss
+++ b/css/core.scss
@@ -107,6 +107,12 @@ a.btn:hover {
   font-family: 'Source Code Pro', monospace;
 }
 
+@media (max-width: 447px){ 
+  .btn-lg { 
+    margin: 1rem;
+   } 
+}
+
 .btn-xl {
   font-size: 25px;
   padding: 20px 70px;

--- a/css/core.scss
+++ b/css/core.scss
@@ -141,6 +141,13 @@ ul.social-buttons {
   margin-bottom: 0;
 }
 
+@media (max-width:417px){
+  ul.social-buttons {
+    display: flex;
+    justify-content: center;
+  }
+}
+
 ul.social-buttons li a {
   cursor: pointer;
   font-size: 20px;


### PR DESCRIPTION
Added media query for social buttons to fix button layout in mobile devices with a width of 417px or smaller.