### PR TITLE
Fix mobile navigation button doesn't fit on the same line

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,10 +25,12 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
     execjs (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
+    ffi (1.13.1-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (209)
@@ -211,6 +213,8 @@ GEM
     multipart-post (2.1.1)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    nokogiri (1.10.10-x64-mingw32)
+      mini_portile2 (~> 2.4.0)
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -246,12 +250,14 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
+    unf_ext (0.0.7.7-x64-mingw32)
     unicode-display_width (1.7.0)
     wdm (0.1.1)
     zeitwerk (2.4.0)
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   github-pages

--- a/css/core.scss
+++ b/css/core.scss
@@ -274,6 +274,7 @@ img::-moz-selection {
     font-size: 1.5em;
     -webkit-transition: all 0.3s;
     transition: all 0.3s;
+    margin-right: 0;
   }
 
   #mainNav .navbar-toggler {


### PR DESCRIPTION
The issue:
On a small screen (360px was used based on samsung s9+), the mobile navigation button doesn't fit on the same row with the brand. So, it is forced to the second row but jumps back up to the first row with the brand when the user scroll. This is because the bootstrap class 'navbar-brand' by default has a margin-right of 1rem and the container is set to justify-content: space-between (which put space between the brand and navigation button). With these two properties, the navigation button is unable to remain in same row as the brand because there is not enough space so it wraps.

The solution:
I overrode the default bootstrap margin-right of 1rem in the 'navbar-brand' class by adding margin-right: 0 to the existing selector in core.css file, which has a higher specificity. Nothing was broken in the process. 