### PR TITLE
Fix [a11y] background and foreground contrast ratio

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,10 +25,12 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
     execjs (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
+    ffi (1.13.1-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (209)
@@ -211,6 +213,8 @@ GEM
     multipart-post (2.1.1)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    nokogiri (1.10.10-x64-mingw32)
+      mini_portile2 (~> 2.4.0)
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -246,12 +250,14 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
+    unf_ext (0.0.7.7-x64-mingw32)
     unicode-display_width (1.7.0)
     wdm (0.1.1)
     zeitwerk (2.4.0)
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   github-pages

--- a/css/core.scss
+++ b/css/core.scss
@@ -707,7 +707,7 @@ blockquote footer,
 blockquote small {
   font-size: 80%;
   line-height: 1.42857143;
-  color: #777;
+  color: #595959;
 }
 
 blockquote .small:before,

--- a/css/core.scss
+++ b/css/core.scss
@@ -274,6 +274,7 @@ img::-moz-selection {
     font-size: 1.5em;
     -webkit-transition: all 0.3s;
     transition: all 0.3s;
+    margin-right: 0;
   }
 
   #mainNav .navbar-toggler {


### PR DESCRIPTION
Issue:
On mobile devices, under the "Here's what people are saying about us" section, the color contrast between background and foreground content (in this case, the names of the people) is not great enough to ensure legibility. The WCAG guidelines recommend a contrast ratio of 4.5:1 for AA rating and 7:1 for AAA rating. The foreground content had a color value of `#777`, which did not meet any of the aforementioned rating.

Solution:
The color value of `#707070` pass the AA rating, and the value of `#595959` pass the AAA rating. Seeing that the two shades of gray are not very different, I implemented the latter since it passed the AAA rating. Nothing is broken.