### PR TITLE
Switch Primary Event Listing Platform to Meetup.com

### DIFF
--- a/learn.html
+++ b/learn.html
@@ -124,14 +124,15 @@ title: Learn
       <div class="col-md-8 col-lg-6">
         <div class="card shadow">
           <div class="p-4 p-md-5 text-center">
-            <h2 class="text-center mb-5">Upcoming events</h2>
+            <h2 class="text-center mb-2">Upcoming events</h2>
+            <p class="text-muted mb-5">As a key player in the Memphis Technology User Groups, Code Connector organizes workshops, meetups, and events that bring tech enthusiasts together to learn, network, and explore new technologies.</p>
+
             <!--
             <div class="embed-responsive embed-responsive-16by9 mb-4">
               <iframe class="embed-responsive-item" src="https://calendar.google.com/calendar/b/1/embed?showTitle=0&amp;showNav=0&amp;showDate=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=AGENDA&amp;height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;src=fgcsik1e9m63qqnc4qehgernk8%40group.calendar.google.com&amp;color=%23ffffff&amp;src=mbfvofsq427ncq7huc0otcgb48%40group.calendar.google.com&amp;color=%23ffffff&amp;src=ebk4jgggi3m4so9vss1mujrdng%40group.calendar.google.com&amp;color=%23ffffff&amp;src=7hg2nohh1qkbbomb0j0kipbm04%40group.calendar.google.com&amp;color=%23ffffff&amp;ctz=America%2FNew_York" width="800" height="400" scrolling="yes"></iframe>
             </div>
             -->
-            <a class="btn btn-primary" href="https://www.facebook.com/codeconnective/events" target="_blank" rel="noopener">Facebook</a>
-            <a class="btn btn-primary" href="https://www.eventbrite.com/o/code-connector-15650145492" target="_blank" rel="noopener">Eventbrite</a>
+            <a class="btn btn-primary" href="https://www.meetup.com/memphis-technology-user-groups/events" target="_blank" rel="noopener">Meetup</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR closes #116 

- Updated the Code Connector website to reflect the use of Meetup.com as the primary platform for listing upcoming events.
- Added a brief explanation of Code Connector's association with the Memphis Technology User Groups.

![image](https://github.com/codeconnector/codeconnector.github.io/assets/59674245/ebf7ef2c-fd52-4d01-aded-4ae937725113)
